### PR TITLE
Add support for servo motors (PWM outputs) for rddrone_fmuk66 RevD

### DIFF
--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66-pinctrl.dtsi
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66-pinctrl.dtsi
@@ -53,7 +53,7 @@
 	ftm0_default: ftm0_default {
 		group0 {
 			pinmux = <FTM0_CH0_PTC1>,
-				<FTM0_CH1_PTA4>,
+				<FTM0_CH3_PTA6>,
 				<FTM0_CH4_PTD4>,
 				<FTM0_CH5_PTD5>;
 			drive-strength = "low";

--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -77,6 +77,18 @@
 		standby-gpios = <&gpioc 18 GPIO_ACTIVE_HIGH>;
 		#phy-cells = <0>;
 	};
+
+	servo: servo {
+		compatible = "pwm-servo";
+		pwms = <&ftm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>, // FMU_CH1
+			   <&ftm0 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>, // FMU_CH2
+			   <&ftm0 4 PWM_MSEC(20) PWM_POLARITY_NORMAL>, // FMU_CH3
+			   <&ftm0 5 PWM_MSEC(20) PWM_POLARITY_NORMAL>, // FMU_CH4
+			   <&ftm3 6 PWM_MSEC(20) PWM_POLARITY_NORMAL>, // FMU_CH5
+			   <&ftm3 7 PWM_MSEC(20) PWM_POLARITY_NORMAL>; // FMU_CH6
+		min-pulse = <PWM_USEC(700)>;
+		max-pulse = <PWM_USEC(2500)>;
+	};
 };
 
 &sim {


### PR DESCRIPTION
Configure the device tree to expose PWM outputs (servos). One issue was that the FTM0 pinmux had an incorrect entry. The second PWM channel was incorrectly pinmuxed to FTM0_CH1_PTA4, whereas this should be pinmuxed to FTM0_CH3_PTA6. 